### PR TITLE
Add multilingual toggle and image placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
     .nav .links{display:flex;gap:20px;align-items:center}
     .btn{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;border:1px solid rgba(255,255,255,.12);background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02));box-shadow:0 10px 30px rgba(0,0,0,.3);color:var(--text)}
     .btn:hover{transform:translateY(-1px);}
+    .lang-buttons{display:flex;gap:6px}
+    .lang-btn{padding:6px 10px;font-size:14px}
     .hero{display:grid;grid-template-columns:1.2fr 1fr;gap:28px;align-items:center;padding:64px 0 40px}
     .badge{display:inline-flex;gap:8px;align-items:center;font-size:12px;padding:6px 10px;border:1px solid rgba(255,255,255,.12);border-radius:999px;color:var(--muted)}
     h1{font-size:clamp(34px, 4vw, 54px);line-height:1.05;margin:14px 0 12px}
@@ -77,10 +79,15 @@
         Fermaths
       </a>
       <div class="links">
-        <a href="#how">How it works</a>
-        <a href="#features">Features</a>
-        <a href="#gallery">Gallery</a>
-        <a href="#contact" class="btn" aria-label="Go to contact page">Contact</a>
+        <a href="#how" data-i18n="navHow">How it works</a>
+        <a href="#features" data-i18n="navFeatures">Features</a>
+        <a href="#gallery" data-i18n="navGallery">Gallery</a>
+        <a href="#contact" class="btn" aria-label="Go to contact page" data-i18n="navContact">Contact</a>
+        <div class="lang-buttons">
+          <button class="btn lang-btn" data-lang="en">EN</button>
+          <button class="btn lang-btn" data-lang="es">ES</button>
+          <button class="btn lang-btn" data-lang="ca">CA</button>
+        </div>
       </div>
     </nav>
   </header>
@@ -89,45 +96,16 @@
   <main id="home" class="container">
     <section class="hero">
       <div>
-        <span class="badge" aria-hidden="true">Screen‑free • Movement‑first • Ages 5+</span>
-        <h1>Math that kids can <em>grab</em>, twist, and pat</h1>
-        <p class="lead">Fermaths is a hands‑on toy that turns arithmetic into quick, playful actions. Think of it like a classic call‑and‑response game—but focused on numbers, quick mental math, and problem solving. No screens. Just fun.</p>
+        <span class="badge" aria-hidden="true" data-i18n="badge">Screen‑free • Movement‑first • Ages 5+</span>
+        <h1 data-i18n="heroTitle">Math that kids can <em>grab</em>, twist, and pat</h1>
+        <p class="lead" data-i18n="heroLead">Fermaths is a hands‑on toy that turns arithmetic into quick, playful actions. Think of it like a classic call‑and‑response game—but focused on numbers, quick mental math, and problem solving. No screens. Just fun.</p>
         <div class="hero-cta">
-          <a href="#contact" class="btn" style="border-color:rgba(56,189,248,.5)">Get in touch</a>
-          <a href="#how" class="btn" style="border-color:rgba(167,139,250,.5)">How it works</a>
+          <a href="#contact" class="btn" style="border-color:rgba(56,189,248,.5)" data-i18n="heroGetInTouch">Get in touch</a>
+          <a href="#how" class="btn" style="border-color:rgba(167,139,250,.5)" data-i18n="heroHow">How it works</a>
         </div>
       </div>
       <div class="card" aria-label="Device mockup">
-        <!-- Simple inline SVG mockup of the device -->
-        <svg class="floaty" viewBox="0 0 760 420" width="100%" role="img" aria-label="Illustration of the Fermaths toy">
-          <defs>
-            <linearGradient id="body" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0" stop-color="#0b1220"/>
-              <stop offset="1" stop-color="#1f2937"/>
-            </linearGradient>
-            <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-              <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-            </filter>
-          </defs>
-          <g filter="url(#shadow)">
-            <rect x="50" y="60" rx="80" ry="80" width="660" height="260" fill="url(#body)" stroke="rgba(255,255,255,.15)" stroke-width="3"/>
-            <!-- Grips -->
-            <circle cx="120" cy="190" r="46" fill="#0ea5e9" />
-            <circle cx="640" cy="190" r="46" fill="#a78bfa" />
-            <!-- Action buttons -->
-            <circle cx="300" cy="160" r="22" fill="#22c55e" />
-            <circle cx="360" cy="220" r="22" fill="#f59e0b" />
-            <circle cx="420" cy="160" r="22" fill="#ef4444" />
-            <!-- Speaker holes -->
-            <g fill="#111827" opacity=".8">
-              <circle cx="540" cy="150" r="4"/><circle cx="556" cy="150" r="4"/><circle cx="572" cy="150" r="4"/>
-              <circle cx="540" cy="166" r="4"/><circle cx="556" cy="166" r="4"/><circle cx="572" cy="166" r="4"/>
-            </g>
-            <!-- Label -->
-            <rect x="290" y="270" width="180" height="34" rx="8" fill="rgba(255,255,255,.06)" stroke="rgba(255,255,255,.12)"/>
-            <text x="380" y="293" text-anchor="middle" fill="#e5e7eb" font-size="18" font-weight="600">Fermaths</text>
-          </g>
-        </svg>
+        <img src="img1.png" alt="Fermaths device" width="100%" class="floaty"/>
       </div>
     </section>
 
@@ -173,78 +151,34 @@
 
     <!-- Gallery (device images / mockups) -->
     <section id="gallery">
-      <h2>Gallery</h2>
-      <p class="muted">A few concept mockups of the device while we finalize the industrial design.</p>
+      <h2 data-i18n="galleryHeading">Gallery</h2>
+      <p class="muted" data-i18n="galleryDescription">A few concept mockups of the device while we finalize the industrial design.</p>
       <div class="gallery" aria-label="Device image gallery">
         <figure class="card">
-          <svg viewBox="0 0 760 420" width="100%" aria-label="Fermaths device front view" class="floaty">
-            <use href="#device-front" />
-          </svg>
-          <figcaption class="muted">Front view</figcaption>
+          <img src="img2.png" alt="Fermaths device front view" width="100%" class="floaty"/>
+          <figcaption class="muted" data-i18n="galleryFront">Front view</figcaption>
         </figure>
         <figure class="card">
-          <svg viewBox="0 0 760 420" width="100%" aria-label="Fermaths device angled view" class="floaty" style="animation-duration:7s">
-            <use href="#device-angled" />
-          </svg>
-          <figcaption class="muted">Angled view</figcaption>
+          <img src="img3.png" alt="Fermaths device angled view" width="100%" class="floaty" style="animation-duration:7s"/>
+          <figcaption class="muted" data-i18n="galleryAngled">Angled view</figcaption>
         </figure>
         <figure class="card">
-          <svg viewBox="0 0 760 420" width="100%" aria-label="Fermaths device in a child's hands" class="floaty" style="animation-duration:5.5s">
-            <use href="#device-hands" />
-          </svg>
-          <figcaption class="muted">In small hands</figcaption>
+          <img src="img4.png" alt="Fermaths device in a child's hands" width="100%" class="floaty" style="animation-duration:5.5s"/>
+          <figcaption class="muted" data-i18n="galleryHands">In small hands</figcaption>
         </figure>
       </div>
-
-      <!-- SVG symbol defs so we can reuse shapes -->
-      <svg class="sr-only" aria-hidden="true">
-        <symbol id="shell">
-          <defs>
-            <linearGradient id="body2" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0" stop-color="#0b1220"/>
-              <stop offset="1" stop-color="#1f2937"/>
-            </linearGradient>
-          </defs>
-          <rect x="50" y="60" rx="80" ry="80" width="660" height="260" fill="url(#body2)" stroke="rgba(255,255,255,.15)" stroke-width="3"/>
-          <circle cx="120" cy="190" r="46" fill="#0ea5e9" />
-          <circle cx="640" cy="190" r="46" fill="#a78bfa" />
-          <circle cx="300" cy="160" r="22" fill="#22c55e" />
-          <circle cx="360" cy="220" r="22" fill="#f59e0b" />
-          <circle cx="420" cy="160" r="22" fill="#ef4444" />
-        </symbol>
-        <symbol id="device-front" viewBox="0 0 760 420">
-          <use href="#shell" />
-          <rect x="290" y="270" width="180" height="34" rx="8" fill="rgba(255,255,255,.06)" stroke="rgba(255,255,255,.12)"/>
-          <text x="380" y="293" text-anchor="middle" fill="#e5e7eb" font-size="18" font-weight="600">Fermaths</text>
-        </symbol>
-        <symbol id="device-angled" viewBox="0 0 760 420">
-          <g transform="skewX(-8) translate(-30, 0)">
-            <use href="#shell" />
-            <rect x="290" y="270" width="180" height="34" rx="8" fill="rgba(255,255,255,.06)" stroke="rgba(255,255,255,.12)"/>
-            <text x="380" y="293" text-anchor="middle" fill="#e5e7eb" font-size="18" font-weight="600">Fermaths</text>
-          </g>
-        </symbol>
-        <symbol id="device-hands" viewBox="0 0 760 420">
-          <use href="#shell" />
-          <!-- Simple hands -->
-          <g opacity=".9">
-            <ellipse cx="120" cy="250" rx="60" ry="28" fill="#f4a261"/>
-            <ellipse cx="640" cy="250" rx="60" ry="28" fill="#f4a261"/>
-          </g>
-        </symbol>
-      </svg>
     </section>
 
     <!-- Contact (acts as a dedicated contact page/section) -->
     <section id="contact" aria-labelledby="contact-heading">
       <div class="card">
-        <h2 id="contact-heading">Contact</h2>
-        <p class="muted">Questions, partnerships, or early access? Reach out—we'd love to hear from you.</p>
+        <h2 id="contact-heading" data-i18n="contactHeading">Contact</h2>
+        <p class="muted" data-i18n="contactDescription">Questions, partnerships, or early access? Reach out—we'd love to hear from you.</p>
         <div class="contact-card">
           <div class="stack">
-            <h3>Email</h3>
+            <h3 data-i18n="email">Email</h3>
             <p><a href="mailto:opotek.fermaths@protonmail.com">opotek.fermaths@protonmail.com</a></p>
-            <h3>Phone</h3>
+            <h3 data-i18n="phone">Phone</h3>
             <p><a href="tel:+34646617993">(+34) 646 617 993</a></p>
           </div>
           <form class="stack" onsubmit="event.preventDefault(); alert('Thanks! We\'ll be in touch shortly.');" aria-label="Quick contact form">
@@ -256,8 +190,8 @@
               <span class="sr-only">Your message</span>
               <textarea required name="message" placeholder="Hello! I'd like to learn more…" rows="4" style="width:100%;padding:12px 14px;border-radius:12px;border:1px solid rgba(255,255,255,.16);background:#0b1020;color:var(--text)"></textarea>
             </label>
-            <button class="btn" type="submit" aria-label="Send message">Send message</button>
-            <p class="muted" style="font-size:12px">We use your details only to contact you back. No spam, ever.</p>
+            <button class="btn" type="submit" aria-label="Send message" data-i18n="sendMessage">Send message</button>
+            <p class="muted" style="font-size:12px" data-i18n="formDisclaimer">We use your details only to contact you back. No spam, ever.</p>
           </form>
         </div>
       </div>
@@ -267,11 +201,94 @@
   <footer class="footer">
     <div class="container" style="display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap">
       <span>© <span id="y"></span> Fermaths, an OPOTEK Project</span>
-      <span class="muted">Made for playful math learning</span>
+      <span class="muted" data-i18n="footerMade">Made for playful math learning</span>
     </div>
   </footer>
 
   <script>
+    const translations = {
+      en: {
+        navHow: "How it works",
+        navFeatures: "Features",
+        navGallery: "Gallery",
+        navContact: "Contact",
+        badge: "Screen‑free • Movement‑first • Ages 5+",
+        heroTitle: "Math that kids can <em>grab</em>, twist, and pat",
+        heroLead: "Fermaths is a hands‑on toy that turns arithmetic into quick, playful actions. Think of it like a classic call‑and‑response game—but focused on numbers, quick mental math, and problem solving. No screens. Just fun.",
+        heroGetInTouch: "Get in touch",
+        heroHow: "How it works",
+        galleryHeading: "Gallery",
+        galleryDescription: "A few concept mockups of the device while we finalize the industrial design.",
+        galleryFront: "Front view",
+        galleryAngled: "Angled view",
+        galleryHands: "In small hands",
+        contactHeading: "Contact",
+        contactDescription: "Questions, partnerships, or early access? Reach out—we'd love to hear from you.",
+        email: "Email",
+        phone: "Phone",
+        sendMessage: "Send message",
+        formDisclaimer: "We use your details only to contact you back. No spam, ever.",
+        footerMade: "Made for playful math learning"
+      },
+      es: {
+        navHow: "Cómo funciona",
+        navFeatures: "Características",
+        navGallery: "Galería",
+        navContact: "Contacto",
+        badge: "Sin pantallas • Movimiento primero • A partir de 5 años",
+        heroTitle: "Matemáticas que los niños pueden <em>agarrar</em>, girar y tocar",
+        heroLead: "Fermaths es un juguete práctico que convierte la aritmética en acciones rápidas y divertidas. Piénsalo como un juego clásico de llamada y respuesta, pero enfocado en números, cálculo mental rápido y resolución de problemas. Sin pantallas. Solo diversión.",
+        heroGetInTouch: "Contactar",
+        heroHow: "Cómo funciona",
+        galleryHeading: "Galería",
+        galleryDescription: "Algunos bocetos conceptuales del dispositivo mientras finalizamos el diseño industrial.",
+        galleryFront: "Vista frontal",
+        galleryAngled: "Vista en ángulo",
+        galleryHands: "En manos pequeñas",
+        contactHeading: "Contacto",
+        contactDescription: "¿Preguntas, colaboraciones o acceso anticipado? Contáctanos, nos encantará saber de ti.",
+        email: "Correo",
+        phone: "Teléfono",
+        sendMessage: "Enviar mensaje",
+        formDisclaimer: "Usamos tus datos solo para contactar contigo. Nada de spam.",
+        footerMade: "Hecho para un aprendizaje lúdico de matemáticas"
+      },
+      ca: {
+        navHow: "Com funciona",
+        navFeatures: "Característiques",
+        navGallery: "Galeria",
+        navContact: "Contacte",
+        badge: "Sense pantalles • Moviment primer • A partir de 5 anys",
+        heroTitle: "Matemàtiques que els nens poden <em>agafar</em>, girar i tocar",
+        heroLead: "Fermaths és un joc pràctic que converteix l'aritmètica en accions ràpides i divertides. Pensa-hi com un joc clàssic de pregunta i resposta, però centrat en nombres, càlcul mental ràpid i resolució de problemes. Sense pantalles. Només diversió.",
+        heroGetInTouch: "Contacta'ns",
+        heroHow: "Com funciona",
+        galleryHeading: "Galeria",
+        galleryDescription: "Alguns esbossos conceptuals del dispositiu mentre finalitzem el disseny industrial.",
+        galleryFront: "Vista frontal",
+        galleryAngled: "Vista angular",
+        galleryHands: "En mans petites",
+        contactHeading: "Contacte",
+        contactDescription: "Preguntes, col·laboracions o accés anticipat? Escriu-nos, ens encantarà saber de tu.",
+        email: "Correu",
+        phone: "Telèfon",
+        sendMessage: "Enviar missatge",
+        formDisclaimer: "Fem servir les teves dades només per contactar-te. Cap spam.",
+        footerMade: "Fet per a l'aprenentatge lúdic de les matemàtiques"
+      }
+    };
+
+    function setLang(lang){
+      document.querySelectorAll('[data-i18n]').forEach(el=>{
+        const key = el.getAttribute('data-i18n');
+        el.innerHTML = translations[lang][key] || translations.en[key] || '';
+      });
+      document.documentElement.lang = lang;
+    }
+    document.querySelectorAll('.lang-btn').forEach(btn=>{
+      btn.addEventListener('click', ()=>setLang(btn.dataset.lang));
+    });
+    setLang('en');
     // Set year
     document.getElementById('y').textContent = new Date().getFullYear();
     // Smooth scroll for internal links


### PR DESCRIPTION
## Summary
- enable English, Spanish, and Catalan views with new language selector and translation script
- replace inline device mockups with `img1.png` hero and `img2.png`–`img4.png` gallery placeholders

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6504929883258fd900853a837806